### PR TITLE
Don't use format %s to copy strings

### DIFF
--- a/ido-hacks.el
+++ b/ido-hacks.el
@@ -296,7 +296,7 @@ is minibuffer. (Stolen from icomplete.)"
     (if (and ido-use-faces comps)
         (let* ((fn (ido-name (car comps)))
                (ln (length fn)))
-          (setq first (format "%s" fn))
+          (setq first (copy-sequence fn))
           (put-text-property 0 ln 'face
                              (if (= (length comps) 1)
                                  (if ido-incomplete-regexp


### PR DESCRIPTION
format doesn't create a fresh string and this can mean that
`ido-completions` will break when it tries to add text properties to
some symbol names

- problem / fix reported here in emacs upstream
  https://github.com/emacs-mirror/emacs/commit/b78332c3c646be12d252a637ce0fc949919a840b

- located via https://github.com/DarwinAwardWinner/ido-completing-read-plus/issues/141